### PR TITLE
Remove duplicate variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -99,7 +99,6 @@ grafana_default:
   max_open_files: 10000
   plugins_dir: "{{ grafana_dir_plugins }}"
   restart_on_upgrade: 'false'
-  restart_on_upgrade: 'false'
   pid_file_dir: "{{ grafana_dir_pid }}"
 
 


### PR DESCRIPTION
  * Remove extra `restart_on_upgrade` var from defaults/main.yml as
    reported by ansible during a playbook run.